### PR TITLE
Improve Application Versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ DEFAULT: build
 GO           ?= go
 GOFMT        ?= $(GO)fmt
 DOCKER_ORG   := xmidt
+APP          := gungnir
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 GUNGNIR    := $(FIRST_GOPATH)/bin/gungnir
 
 PROGVER = $(shell git describe --tags `git rev-list --tags --max-count=1` | tail -1 | sed 's/v\(.*\)/\1/')
+RPM_VERSION=$(shell echo $(PROGVER) | sed 's/\(.*\)-\(.*\)/\1/')
+RPM_RELEASE=$(shell echo $(PROGVER) | sed -n 's/.*-\(.*\)/\1/p'  | grep . && (echo "$(echo $(PROGVER) | sed 's/.*-\(.*\)/\1/')") || echo "1")
+BUILDTIME = $(shell date -u '+%Y-%m-%d %H:%M:%S')
+GITCOMMIT = $(shell git rev-parse --short HEAD)
 
 .PHONY: go-mod-vendor
 go-mod-vendor:
@@ -18,16 +23,16 @@ build: go-mod-vendor
 
 rpm:
 	mkdir -p ./OPATH/SOURCES
-	tar -czvf ./OPATH/SOURCES/gungnir-$(PROGVER).tar.gz . --exclude ./.git --exclude ./OPATH --exclude ./conf --exclude ./deploy --exclude ./vendor
-	cp conf/gungnir.service ./OPATH/SOURCES/
-	cp conf/gungnir.yaml  ./OPATH/SOURCES/
+	tar -czvf ./OPATH/SOURCES/$(APP)-$(RPM_VERSION)-$(RPM_RELEASE).tar.gz . --exclude ./.git --exclude ./OPATH --exclude ./conf --exclude ./deploy --exclude ./vendor
+	cp conf/$(APP).service ./OPATH/SOURCES/
+	cp conf/$(APP).yaml  ./OPATH/SOURCES/
 	cp LICENSE ./OPATH/SOURCES/
 	cp NOTICE ./OPATH/SOURCES/
 	cp CHANGELOG.md ./OPATH/SOURCES/
 	rpmbuild --define "_topdir $(CURDIR)/OPATH" \
-    		--define "_version $(PROGVER)" \
-    		--define "_release 1" \
-    		-ba deploy/packaging/gungnir.spec
+		--define "_version $(RPM_VERSION)" \
+		--define "_release $(RPM_RELEASE)" \
+		-ba deploy/packaging/$(APP).spec
 
 .PHONY: version
 version:
@@ -45,26 +50,34 @@ endif
 .PHONY: update-version
 update-version:
 	@echo "Update Version $(PROGVER) to $(RUN_ARGS)"
-	sed -i "s/$(PROGVER)/$(RUN_ARGS)/g" main.go
+	git tag v$(RUN_ARGS)
 
 
 .PHONY: install
 install: go-mod-vendor
-	go install -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)"
+	go install -ldflags "-X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(PROGVER)"
 
 .PHONY: release-artifacts
 release-artifacts: go-mod-vendor
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./OPATH/gungnir-$(PROGVER).darwin-amd64
-	GOOS=linux  GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./OPATH/gungnir-$(PROGVER).linux-amd64
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(PROGVER)" -o ./OPATH/gungnir-$(PROGVER).darwin-amd64
+	GOOS=linux  GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(PROGVER)" -o ./OPATH/gungnir-$(PROGVER).linux-amd64
 
 .PHONY: docker
 docker:
-	docker build --build-arg VERSION=$(PROGVER) -f ./deploy/Dockerfile -t $(DOCKER_ORG)/gungnir:$(PROGVER) .
+	docker build \
+		--build-arg VERSION=$(PROGVER) \
+		--build-arg GITCOMMIT=$(GITCOMMIT) \
+		--build-arg BUILDTIME='$(BUILDTIME)' \
+		-f ./deploy/Dockerfile -t $(DOCKER_ORG)/gungnir:$(PROGVER) .
 
 # build docker without running modules
 .PHONY: local-docker
 local-docker:
-	docker build --build-arg VERSION=$(PROGVER)+local -f ./deploy/Dockerfile.local -t $(DOCKER_ORG)/gungnir:local .
+	docker build \
+		--build-arg VERSION=$(PROGVER)+local \
+		--build-arg GITCOMMIT=$(GITCOMMIT) \
+		--build-arg BUILDTIME='$(BUILDTIME)' \
+		-f ./deploy/Dockerfile.local -t $(DOCKER_ORG)/gungnir:local .
 
 .PHONY: style
 style:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/gungnir
+ARG VERSION=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -o gungnir_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o gungnir_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/gungnir
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o gungnir_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o gungnir_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/gungnir
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o gungnir_linux_amd64 github.com/xmidt-org/gungnir
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o gungnir_linux_amd64 github.com/xmidt-org/gungnir
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/gungnir
+ARG VERSION=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -o gungnir_linux_amd64 github.com/xmidt-org/gungnir
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o gungnir_linux_amd64 github.com/xmidt-org/gungnir
 
 FROM alpine
 

--- a/deploy/packaging/gungnir.spec
+++ b/deploy/packaging/gungnir.spec
@@ -23,7 +23,7 @@ The spear used with shield to help our users via the codex project
 aka. The api layer to get the data from the database.
 
 %build
-GO111MODULE=on go build -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
+GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=%{_version}" -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
 
 %install
 echo rm -rf %{buildroot}

--- a/main.go
+++ b/main.go
@@ -20,11 +20,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	olog "log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"time"
 
 	"github.com/xmidt-org/codex-db/retry"
@@ -57,7 +59,12 @@ import (
 const (
 	applicationName, apiBase = "gungnir", "/api/v1"
 	DEFAULT_KEY_ID           = "current"
-	applicationVersion       = "0.10.0"
+)
+
+var (
+	GitCommit = "undefined"
+	Version   = "undefined"
+	BuildTime = "undefined"
 )
 
 type Config struct {
@@ -224,10 +231,19 @@ func printVersion(f *pflag.FlagSet, arguments []string) (error, bool) {
 	}
 
 	if *printVer {
-		fmt.Println(applicationVersion)
+		printVersionInfo(os.Stdout)
 		return nil, true
 	}
 	return nil, false
+}
+
+func printVersionInfo(writer io.Writer) {
+	fmt.Fprintf(writer, "%s:\n", applicationName)
+	fmt.Fprintf(writer, "  version: \t%s\n", Version)
+	fmt.Fprintf(writer, "  go version: \t%s\n", runtime.Version())
+	fmt.Fprintf(writer, "  built time: \t%s\n", BuildTime)
+	fmt.Fprintf(writer, "  git commit: \t%s\n", GitCommit)
+	fmt.Fprintf(writer, "  os/arch: \t%s/%s\n", runtime.GOOS, runtime.GOARCH)
 }
 
 func exitIfError(logger log.Logger, err error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,1 +1,80 @@
 package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintVersionInfo(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedOutput []string
+		overrideValues func()
+		lineCount      int
+	}{
+		{
+			"default",
+			[]string{
+				"gungnir:",
+				"version: \tundefined",
+				"go version: \tgo",
+				"built time: \tundefined",
+				"git commit: \tundefined",
+				"os/arch: \t",
+			},
+			func() {},
+			6,
+		},
+		{
+			"set values",
+			[]string{
+				"gungnir:",
+				"version: \t1.0.0\n",
+				"go version: \tgo",
+				"built time: \tsome time\n",
+				"git commit: \tgit sha\n",
+				"os/arch: \t",
+			},
+			func() {
+				Version = "1.0.0"
+				BuildTime = "some time"
+				GitCommit = "git sha"
+			},
+			6,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobals()
+			tc.overrideValues()
+			buf := &bytes.Buffer{}
+			printVersionInfo(buf)
+			count := 0
+			for {
+				line, err := buf.ReadString(byte('\n'))
+				if err != nil {
+					break
+				}
+				assert.Contains(t, line, tc.expectedOutput[count])
+				if strings.Contains(line, "\t") {
+					keyAndValue := strings.Split(line, "\t")
+					// The value after the tab should have more than 2 characters
+					// 1) the first character of the value and the new line
+					assert.True(t, len(keyAndValue[1]) > 2)
+				}
+				count++
+			}
+			assert.Equal(t, tc.lineCount, count)
+			resetGlobals()
+		})
+	}
+}
+
+func resetGlobals() {
+	Version = "undefined"
+	BuildTime = "undefined"
+	GitCommit = "undefined"
+}


### PR DESCRIPTION
This will allow for better bug reports and information the binary running.
This information can be retrieved upon providing the -v or --version
flag

Closes #84 

```
docker run --rm xmidt/gungnir:local -v 
gungnir:
  version:      0.10.0+local
  go version:   go1.13.1
  built time:   2019-10-13 22:52:55
  git commit:   aa49b02
  os/arch:      linux/amd64
```